### PR TITLE
Interactive question box on the Questions page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+server/data/
+server/node_modules/

--- a/Kevin Sun/style.css
+++ b/Kevin Sun/style.css
@@ -109,3 +109,56 @@ sub {
 sub {
   top: 0.4em;
 }
+
+#qa-box {
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding: 12px 14px;
+  margin: 1.5em 0;
+}
+
+#qa-form {
+  display: flex;
+  gap: 6px;
+}
+
+#qa-input {
+  flex: 1;
+  font: inherit;
+  color: #333;
+  padding: 6px 8px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+}
+
+#qa-form button {
+  font: inherit;
+  color: #333;
+  padding: 6px 14px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background: #fff;
+  cursor: pointer;
+}
+
+#qa-form button:hover {
+  background: #f4f4f4;
+}
+
+.qa-entry {
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  padding: 8px 10px;
+  margin-top: 10px;
+  color: #333;
+  line-height: 18px;
+  overflow-wrap: break-word;
+}
+
+.qa-entry div + div {
+  margin-top: 6px;
+}
+
+.qa-ts {
+  color: #aaa;
+}

--- a/questions.html
+++ b/questions.html
@@ -20,8 +20,22 @@
       <div id="content">
         <p>
           I'm pretty curious about the world. Here are some of the questions
-          that percolate in my mind.
+          that percolate in my mind. You can also ask me yours.
         </p>
+
+        <div id="qa-box">
+          <p class="note notop">i usually respond day of.</p>
+          <form id="qa-form">
+            <input
+              id="qa-input"
+              type="text"
+              maxlength="2000"
+              placeholder="ask me whatever your heart desires. can be anon or u can say ur name"
+            />
+            <button type="submit">ask</button>
+          </form>
+          <div id="qa-feed"></div>
+        </div>
 
         <p>
           <b
@@ -422,5 +436,102 @@
         </p>
       </div>
     </div>
+    <script data-questions-api="https://ask.kyungminsun.com">
+      (function () {
+        var API = document.currentScript.dataset.questionsApi;
+        var feed = document.getElementById("qa-feed");
+        var form = document.getElementById("qa-form");
+        var input = document.getElementById("qa-input");
+
+        var ORDINALS = { 1: "st", 2: "nd", 3: "rd", 21: "st", 22: "nd", 23: "rd", 31: "st" };
+        function fmt(iso) {
+          var parts = new Intl.DateTimeFormat("en-US", {
+            timeZone: "America/Los_Angeles",
+            month: "long",
+            day: "numeric",
+            year: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+            hour12: true,
+            timeZoneName: "short",
+          }).formatToParts(new Date(iso));
+          var p = {};
+          parts.forEach(function (x) {
+            p[x.type] = x.value;
+          });
+          var day = p.day + (ORDINALS[+p.day] || "th");
+          return (
+            p.month.toLowerCase() + " " + day + ", " + p.year + ", " +
+            p.hour + ":" + p.minute + p.dayPeriod.toLowerCase() + " " +
+            p.timeZoneName.toLowerCase()
+          );
+        }
+
+        function line(parent, ts, prefix, text) {
+          var div = document.createElement("div");
+          var stamp = document.createElement("span");
+          stamp.className = "qa-ts";
+          stamp.textContent = "[" + fmt(ts) + "] ";
+          div.appendChild(stamp);
+          div.appendChild(document.createTextNode(prefix + ": " + text));
+          parent.appendChild(div);
+        }
+
+        function entryEl(q) {
+          var box = document.createElement("div");
+          box.className = "qa-entry";
+          line(box, q.askedAt, "q", q.question);
+          if (q.answer) line(box, q.answeredAt, "a", q.answer);
+          return box;
+        }
+
+        function notice(text) {
+          feed.textContent = "";
+          var p = document.createElement("p");
+          p.className = "note";
+          p.textContent = text;
+          feed.appendChild(p);
+        }
+
+        function load() {
+          fetch(API + "/api/questions")
+            .then(function (r) {
+              return r.json();
+            })
+            .then(function (data) {
+              feed.textContent = "";
+              data.questions.forEach(function (q) {
+                feed.appendChild(entryEl(q));
+              });
+            })
+            .catch(function () {
+              notice("the question box is napping right now — email me instead.");
+            });
+        }
+
+        form.addEventListener("submit", function (e) {
+          e.preventDefault();
+          var question = input.value.trim();
+          if (!question) return;
+          fetch(API + "/api/ask", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ question: question }),
+          })
+            .then(function (r) {
+              return r.json().then(function (data) {
+                if (!r.ok) throw new Error(data.error || "something went wrong");
+                feed.insertBefore(entryEl(data.question), feed.firstChild);
+                input.value = "";
+              });
+            })
+            .catch(function (err) {
+              alert(err.message);
+            });
+        });
+
+        load();
+      })();
+    </script>
   </body>
 </html>

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,57 @@
+# questions server
+
+The tiny backend behind the questions box on [kyungminsun.com](https://www.kyungminsun.com/questions.html).
+Zero dependencies — plain Bun.
+
+- `POST /api/ask` `{ question, name? }` — stores the question and emails it to me
+- `GET /api/questions` — the public feed, newest first
+- `POST /api/answer` `{ id, answer }` (Bearer `ADMIN_TOKEN`) — posts an answer to the feed
+- `GET /healthz`
+
+Questions live in a single JSON file at `$DATA_DIR/questions.json` (atomic
+writes). Each new question is emailed via [Resend](https://resend.com); the
+email includes a ready-to-paste `curl` for answering it. A failed email never
+drops the question — it's stored first.
+
+## Run locally
+
+```bash
+cd server
+ADMIN_TOKEN=dev bun server.js      # http://localhost:3000
+bun test                           # test suite
+```
+
+Without `RESEND_API_KEY` the server stores questions but skips email — handy
+for local dev.
+
+## Deploy (Railway)
+
+1. New service from this repo, **root directory `server`** (Railpack
+   autodetects Bun from `bun.lock` and runs `bun start`).
+2. Attach a **volume** mounted at `/data`.
+3. Variables:
+
+   | var | value |
+   |---|---|
+   | `DATA_DIR` | `/data` |
+   | `ADMIN_TOKEN` | something long and random |
+   | `RESEND_API_KEY` | from resend.com (verify the sending domain) |
+   | `EMAIL_TO` | defaults to kyungminkevinsun@gmail.com |
+   | `EMAIL_FROM` | defaults to questions@kyungminsun.com |
+   | `ALLOWED_ORIGIN` | `https://www.kyungminsun.com` |
+   | `PUBLIC_URL` | the service's public URL (used in answer emails) |
+
+4. Point the frontend at it: `questions.html` reads the API base from the
+   `data-questions-api` attribute on its `<script>` tag — set it to the
+   service's public URL.
+
+## Answering
+
+Reply day-of by pasting the curl from the notification email:
+
+```bash
+curl -X POST $PUBLIC_URL/api/answer \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "<from the email>", "answer": "good question!"}'
+```

--- a/server/README.md
+++ b/server/README.md
@@ -3,15 +3,13 @@
 The tiny backend behind the questions box on [kyungminsun.com](https://www.kyungminsun.com/questions.html).
 Zero dependencies — plain Bun.
 
-- `POST /api/ask` `{ question, name? }` — stores the question and emails it to me
+- `POST /api/ask` `{ question, name? }` — stores the question
 - `GET /api/questions` — the public feed, newest first
 - `POST /api/answer` `{ id, answer }` (Bearer `ADMIN_TOKEN`) — posts an answer to the feed
 - `GET /healthz`
 
 Questions live in a single JSON file at `$DATA_DIR/questions.json` (atomic
-writes). Each new question is emailed via [Resend](https://resend.com); the
-email includes a ready-to-paste `curl` for answering it. A failed email never
-drops the question — it's stored first.
+writes).
 
 ## Run locally
 
@@ -21,13 +19,10 @@ ADMIN_TOKEN=dev bun server.js      # http://localhost:3000
 bun test                           # test suite
 ```
 
-Without `RESEND_API_KEY` the server stores questions but skips email — handy
-for local dev.
-
 ## Deploy (Railway)
 
 1. New service from this repo, **root directory `server`** (Railpack
-   autodetects Bun from `bun.lock` and runs `bun start`).
+   autodetects Bun and runs `bun start`).
 2. Attach a **volume** mounted at `/data`.
 3. Variables:
 
@@ -35,11 +30,7 @@ for local dev.
    |---|---|
    | `DATA_DIR` | `/data` |
    | `ADMIN_TOKEN` | something long and random |
-   | `RESEND_API_KEY` | from resend.com (verify the sending domain) |
-   | `EMAIL_TO` | defaults to kyungminkevinsun@gmail.com |
-   | `EMAIL_FROM` | defaults to questions@kyungminsun.com |
    | `ALLOWED_ORIGIN` | `https://www.kyungminsun.com` |
-   | `PUBLIC_URL` | the service's public URL (used in answer emails) |
 
 4. Point the frontend at it: `questions.html` reads the API base from the
    `data-questions-api` attribute on its `<script>` tag — set it to the
@@ -47,11 +38,13 @@ for local dev.
 
 ## Answering
 
-Reply day-of by pasting the curl from the notification email:
+Check the feed for new questions, then answer by id:
 
 ```bash
+curl $PUBLIC_URL/api/questions
+
 curl -X POST $PUBLIC_URL/api/answer \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"id": "<from the email>", "answer": "good question!"}'
+  -d '{"id": "<from the feed>", "answer": "good question!"}'
 ```

--- a/server/app.js
+++ b/server/app.js
@@ -3,7 +3,7 @@ const MAX_NAME_LENGTH = 100;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 5;
 
-export function createApp({ store, sendEmail, adminToken, allowedOrigin = "*" }) {
+export function createApp({ store, adminToken, allowedOrigin = "*" }) {
   const hits = new Map(); // ip → [timestamps], pruned per request
 
   function rateLimited(ip) {
@@ -55,10 +55,6 @@ export function createApp({ store, sendEmail, adminToken, allowedOrigin = "*" })
       }
 
       const entry = store.add({ name, question });
-
-      // fire-and-forget: a broken mail pipe should never eat a question
-      sendEmail(entry).catch((err) => console.error("email failed:", err.message));
-
       return json(201, { question: entry });
     }
 

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,88 @@
+const MAX_QUESTION_LENGTH = 2000;
+const MAX_NAME_LENGTH = 100;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 5;
+
+export function createApp({ store, sendEmail, adminToken, allowedOrigin = "*" }) {
+  const hits = new Map(); // ip → [timestamps], pruned per request
+
+  function rateLimited(ip) {
+    const cutoff = Date.now() - RATE_LIMIT_WINDOW_MS;
+    const recent = (hits.get(ip) || []).filter((t) => t > cutoff);
+    recent.push(Date.now());
+    hits.set(ip, recent);
+    return recent.length > RATE_LIMIT_MAX;
+  }
+
+  const corsHeaders = {
+    "Access-Control-Allow-Origin": allowedOrigin,
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  };
+
+  const json = (status, body) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json", ...corsHeaders },
+    });
+
+  return async function handle(req, ip = "?") {
+    const url = new URL(req.url);
+
+    if (req.method === "OPTIONS") return new Response(null, { status: 204, headers: corsHeaders });
+
+    if (req.method === "GET" && url.pathname === "/healthz") return json(200, { ok: true });
+
+    if (req.method === "GET" && url.pathname === "/api/questions") {
+      return json(200, { questions: store.list() });
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/ask") {
+      if (rateLimited(ip)) return json(429, { error: "slow down a little!" });
+
+      let body;
+      try {
+        body = await req.json();
+      } catch {
+        return json(400, { error: "invalid json" });
+      }
+
+      const question = typeof body.question === "string" ? body.question.trim() : "";
+      const name = typeof body.name === "string" ? body.name.trim().slice(0, MAX_NAME_LENGTH) : "";
+      if (!question) return json(400, { error: "question is required" });
+      if (question.length > MAX_QUESTION_LENGTH) {
+        return json(400, { error: `question must be under ${MAX_QUESTION_LENGTH} characters` });
+      }
+
+      const entry = store.add({ name, question });
+
+      // fire-and-forget: a broken mail pipe should never eat a question
+      sendEmail(entry).catch((err) => console.error("email failed:", err.message));
+
+      return json(201, { question: entry });
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/answer") {
+      const auth = req.headers.get("authorization") || "";
+      if (!adminToken || auth !== `Bearer ${adminToken}`) {
+        return json(401, { error: "unauthorized" });
+      }
+
+      let body;
+      try {
+        body = await req.json();
+      } catch {
+        return json(400, { error: "invalid json" });
+      }
+
+      const answer = typeof body.answer === "string" ? body.answer.trim() : "";
+      if (!body.id || !answer) return json(400, { error: "id and answer are required" });
+
+      const entry = store.answer({ id: body.id, answer });
+      if (!entry) return json(404, { error: "no question with that id" });
+      return json(200, { question: entry });
+    }
+
+    return json(404, { error: "not found" });
+  };
+}

--- a/server/app.test.js
+++ b/server/app.test.js
@@ -5,10 +5,10 @@ import { join } from "node:path";
 import { createStore } from "./store.js";
 import { createApp } from "./app.js";
 
-function makeServer({ sendEmail = async () => {}, adminToken = "secret" } = {}) {
+function makeServer({ adminToken = "secret" } = {}) {
   const store = createStore(join(mkdtempSync(join(tmpdir(), "questions-")), "questions.json"));
   let ip = "1.2.3.4";
-  const app = createApp({ store, sendEmail, adminToken });
+  const app = createApp({ store, adminToken });
   const server = Bun.serve({ port: 0, fetch: (req) => app(req, ip) });
   return {
     base: `http://localhost:${server.port}`,
@@ -19,8 +19,7 @@ function makeServer({ sendEmail = async () => {}, adminToken = "secret" } = {}) 
 }
 
 test("ask → list → answer round trip", async () => {
-  const emails = [];
-  const { base, close } = makeServer({ sendEmail: async (e) => emails.push(e) });
+  const { base, close } = makeServer();
   try {
     const ask = await fetch(`${base}/api/ask`, {
       method: "POST",
@@ -30,8 +29,6 @@ test("ask → list → answer round trip", async () => {
     expect(ask.status).toBe(201);
     const { question: entry } = await ask.json();
     expect(entry.name).toBe("jamie");
-    expect(emails.length).toBe(1);
-    expect(emails[0].question).toBe("how did you get into freight?");
 
     const list = await (await fetch(`${base}/api/questions`)).json();
     expect(list.questions.length).toBe(1);
@@ -88,25 +85,6 @@ test("answer requires the admin token", async () => {
   }
 });
 
-test("a failing email never loses the question", async () => {
-  const { base, close } = makeServer({
-    sendEmail: async () => {
-      throw new Error("smtp on fire");
-    },
-  });
-  try {
-    const ask = await fetch(`${base}/api/ask`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ question: "still there?" }),
-    });
-    expect(ask.status).toBe(201);
-    const list = await (await fetch(`${base}/api/questions`)).json();
-    expect(list.questions.length).toBe(1);
-  } finally {
-    close();
-  }
-});
 
 test("rate limits a chatty ip", async () => {
   const { base, close } = makeServer();

--- a/server/app.test.js
+++ b/server/app.test.js
@@ -1,0 +1,138 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createStore } from "./store.js";
+import { createApp } from "./app.js";
+
+function makeServer({ sendEmail = async () => {}, adminToken = "secret" } = {}) {
+  const store = createStore(join(mkdtempSync(join(tmpdir(), "questions-")), "questions.json"));
+  let ip = "1.2.3.4";
+  const app = createApp({ store, sendEmail, adminToken });
+  const server = Bun.serve({ port: 0, fetch: (req) => app(req, ip) });
+  return {
+    base: `http://localhost:${server.port}`,
+    store,
+    setIp: (v) => (ip = v),
+    close: () => server.stop(true),
+  };
+}
+
+test("ask → list → answer round trip", async () => {
+  const emails = [];
+  const { base, close } = makeServer({ sendEmail: async (e) => emails.push(e) });
+  try {
+    const ask = await fetch(`${base}/api/ask`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ question: "how did you get into freight?", name: "jamie" }),
+    });
+    expect(ask.status).toBe(201);
+    const { question: entry } = await ask.json();
+    expect(entry.name).toBe("jamie");
+    expect(emails.length).toBe(1);
+    expect(emails[0].question).toBe("how did you get into freight?");
+
+    const list = await (await fetch(`${base}/api/questions`)).json();
+    expect(list.questions.length).toBe(1);
+    expect(list.questions[0].answer).toBeNull();
+
+    const answer = await fetch(`${base}/api/answer`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer secret" },
+      body: JSON.stringify({ id: entry.id, answer: "family business!" }),
+    });
+    expect(answer.status).toBe(200);
+
+    const after = await (await fetch(`${base}/api/questions`)).json();
+    expect(after.questions[0].answer).toBe("family business!");
+    expect(after.questions[0].answeredAt).toBeTruthy();
+  } finally {
+    close();
+  }
+});
+
+test("rejects empty and oversized questions", async () => {
+  const { base, close } = makeServer();
+  try {
+    const empty = await fetch(`${base}/api/ask`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ question: "   " }),
+    });
+    expect(empty.status).toBe(400);
+
+    const huge = await fetch(`${base}/api/ask`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ question: "x".repeat(2001) }),
+    });
+    expect(huge.status).toBe(400);
+  } finally {
+    close();
+  }
+});
+
+test("answer requires the admin token", async () => {
+  const { base, store, close } = makeServer();
+  try {
+    const entry = store.add({ name: "", question: "hi!!" });
+    const bad = await fetch(`${base}/api/answer`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer wrong" },
+      body: JSON.stringify({ id: entry.id, answer: "hello" }),
+    });
+    expect(bad.status).toBe(401);
+  } finally {
+    close();
+  }
+});
+
+test("a failing email never loses the question", async () => {
+  const { base, close } = makeServer({
+    sendEmail: async () => {
+      throw new Error("smtp on fire");
+    },
+  });
+  try {
+    const ask = await fetch(`${base}/api/ask`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ question: "still there?" }),
+    });
+    expect(ask.status).toBe(201);
+    const list = await (await fetch(`${base}/api/questions`)).json();
+    expect(list.questions.length).toBe(1);
+  } finally {
+    close();
+  }
+});
+
+test("rate limits a chatty ip", async () => {
+  const { base, close } = makeServer();
+  try {
+    let last;
+    for (let i = 0; i < 6; i++) {
+      last = await fetch(`${base}/api/ask`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question: `q${i}` }),
+      });
+    }
+    expect(last.status).toBe(429);
+  } finally {
+    close();
+  }
+});
+
+test("newest questions come first", async () => {
+  const { base, store, close } = makeServer();
+  try {
+    store.add({ question: "first", now: new Date("2026-06-05T17:37:00Z") });
+    store.add({ question: "second", now: new Date("2026-06-07T19:34:00Z") });
+    const list = await (await fetch(`${base}/api/questions`)).json();
+    expect(list.questions.map((q) => q.question)).toEqual(["second", "first"]);
+  } finally {
+    close();
+  }
+});

--- a/server/bunfig.toml
+++ b/server/bunfig.toml
@@ -1,0 +1,1 @@
+# zero-dependency bun app — this file pins Railpack/Railway to the Bun runtime

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "questions-server",
+  "version": "1.0.0",
+  "description": "Tiny server behind the questions box on kyungminsun.com — stores questions and pipes them to email",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "bun server.js",
+    "test": "bun test"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,59 @@
+import { join } from "node:path";
+import { createStore } from "./store.js";
+import { createApp } from "./app.js";
+
+const PORT = process.env.PORT || 3000;
+const DATA_DIR = process.env.DATA_DIR || "./data";
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN;
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || "*";
+const RESEND_API_KEY = process.env.RESEND_API_KEY;
+const EMAIL_TO = process.env.EMAIL_TO || "kyungminkevinsun@gmail.com";
+const EMAIL_FROM = process.env.EMAIL_FROM || "questions@kyungminsun.com";
+const PUBLIC_URL = process.env.PUBLIC_URL || `http://localhost:${PORT}`;
+
+if (!ADMIN_TOKEN) console.warn("ADMIN_TOKEN not set — /api/answer is disabled");
+if (!RESEND_API_KEY) console.warn("RESEND_API_KEY not set — questions will be stored but not emailed");
+
+const store = createStore(join(DATA_DIR, "questions.json"));
+
+async function sendEmail(entry) {
+  if (!RESEND_API_KEY) return;
+  const who = entry.name ? `${entry.name} asks` : "someone asks";
+  // the email contains a ready-to-paste answer command so replying takes one edit
+  const answerCmd = [
+    `curl -X POST ${PUBLIC_URL}/api/answer \\`,
+    `  -H "Authorization: Bearer $ADMIN_TOKEN" \\`,
+    `  -H "Content-Type: application/json" \\`,
+    `  -d '{"id": "${entry.id}", "answer": "..."}'`,
+  ].join("\n");
+
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: `questions <${EMAIL_FROM}>`,
+      to: [EMAIL_TO],
+      subject: `${who}: ${entry.question.slice(0, 80)}`,
+      text: `${entry.question}\n\n— ${entry.name || "anon"}, ${entry.askedAt}\n\nto answer:\n${answerCmd}\n`,
+    }),
+  });
+  if (!res.ok) throw new Error(`resend ${res.status}: ${await res.text()}`);
+}
+
+const app = createApp({
+  store,
+  sendEmail,
+  adminToken: ADMIN_TOKEN,
+  allowedOrigin: ALLOWED_ORIGIN,
+});
+
+const server = Bun.serve({
+  port: PORT,
+  fetch: (req, srv) =>
+    app(req, req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || srv.requestIP(req)?.address || "?"),
+});
+
+console.log(`questions server listening on :${server.port}`);

--- a/server/server.js
+++ b/server/server.js
@@ -6,46 +6,13 @@ const PORT = process.env.PORT || 3000;
 const DATA_DIR = process.env.DATA_DIR || "./data";
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN;
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || "*";
-const RESEND_API_KEY = process.env.RESEND_API_KEY;
-const EMAIL_TO = process.env.EMAIL_TO || "kyungminkevinsun@gmail.com";
-const EMAIL_FROM = process.env.EMAIL_FROM || "questions@kyungminsun.com";
-const PUBLIC_URL = process.env.PUBLIC_URL || `http://localhost:${PORT}`;
 
 if (!ADMIN_TOKEN) console.warn("ADMIN_TOKEN not set — /api/answer is disabled");
-if (!RESEND_API_KEY) console.warn("RESEND_API_KEY not set — questions will be stored but not emailed");
 
 const store = createStore(join(DATA_DIR, "questions.json"));
 
-async function sendEmail(entry) {
-  if (!RESEND_API_KEY) return;
-  const who = entry.name ? `${entry.name} asks` : "someone asks";
-  // the email contains a ready-to-paste answer command so replying takes one edit
-  const answerCmd = [
-    `curl -X POST ${PUBLIC_URL}/api/answer \\`,
-    `  -H "Authorization: Bearer $ADMIN_TOKEN" \\`,
-    `  -H "Content-Type: application/json" \\`,
-    `  -d '{"id": "${entry.id}", "answer": "..."}'`,
-  ].join("\n");
-
-  const res = await fetch("https://api.resend.com/emails", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${RESEND_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      from: `questions <${EMAIL_FROM}>`,
-      to: [EMAIL_TO],
-      subject: `${who}: ${entry.question.slice(0, 80)}`,
-      text: `${entry.question}\n\n— ${entry.name || "anon"}, ${entry.askedAt}\n\nto answer:\n${answerCmd}\n`,
-    }),
-  });
-  if (!res.ok) throw new Error(`resend ${res.status}: ${await res.text()}`);
-}
-
 const app = createApp({
   store,
-  sendEmail,
   adminToken: ADMIN_TOKEN,
   allowedOrigin: ALLOWED_ORIGIN,
 });

--- a/server/store.js
+++ b/server/store.js
@@ -1,0 +1,50 @@
+import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+export function createStore(file) {
+  mkdirSync(dirname(file), { recursive: true });
+
+  function load() {
+    if (!existsSync(file)) return { questions: [] };
+    return JSON.parse(readFileSync(file, "utf8"));
+  }
+
+  // write tmp + rename so a crash mid-write never corrupts the file
+  function save(data) {
+    const tmp = join(dirname(file), `.questions.tmp-${process.pid}`);
+    writeFileSync(tmp, JSON.stringify(data, null, 2));
+    renameSync(tmp, file);
+  }
+
+  return {
+    list() {
+      return load().questions.slice().sort((a, b) => (a.askedAt < b.askedAt ? 1 : -1));
+    },
+
+    add({ name, question, now = new Date() }) {
+      const data = load();
+      const entry = {
+        id: randomUUID(),
+        name: name || null,
+        question,
+        askedAt: now.toISOString(),
+        answer: null,
+        answeredAt: null,
+      };
+      data.questions.push(entry);
+      save(data);
+      return entry;
+    },
+
+    answer({ id, answer, now = new Date() }) {
+      const data = load();
+      const entry = data.questions.find((q) => q.id === id);
+      if (!entry) return null;
+      entry.answer = answer;
+      entry.answeredAt = now.toISOString();
+      save(data);
+      return entry;
+    },
+  };
+}


### PR DESCRIPTION
> Now based on `main`. The Fragments tab moved to its own PR, #7.

## Summary
- Adds a cute interactive ask-me-anything box to the top of the Questions page: one input ("ask me whatever your heart desires. can be anon or u can say ur name"), an **ask** button, and a feed of timestamped entries — `[june 10th, 2026, 11:06am pdt] q: …` with the `a:` line appearing once answered. Styled to match the site's light aesthetic.
- Adds `server/` — a zero-dependency **Bun** service that stores questions in a JSON file:
  - `POST /api/ask` — validates and stores. Per-IP rate limit (5/min).
  - `GET /api/questions` — public feed, newest first.
  - `POST /api/answer` — Bearer `ADMIN_TOKEN`, answer by id.
  - Atomic JSON writes (tmp + rename) at `$DATA_DIR/questions.json`.

## Design
- `server/store.js` (file-backed store) and `server/app.js` (fetch-style handler) are separated so tests run against a temp store. `server/server.js` wires `Bun.serve` and env config.
- Frontend reads the API base from the `data-questions-api` attribute on its script tag (defaults to `https://ask.kyungminsun.com`); if the server is unreachable the box shows "the question box is napping right now — email me instead."
- Timestamps render in PT, lowercase with ordinals, matching the inspo.

## Deploy
`server/README.md` has the Railway runbook: root dir `server`, volume at `/data`, `ADMIN_TOKEN` + `ALLOWED_ORIGIN` env vars. `bunfig.toml` pins Railpack to the Bun runtime. Answering = curl the feed for the id, POST the answer.

## Test plan
- [x] `bun test` — 5 tests: ask→list→answer round trip, validation, auth, rate limiting, ordering
- [x] Ran the server locally, seeded questions via curl (one answered, one not), and rendered the page against it in headless Chrome — feed matches the inspo
- [ ] After deploy: set `data-questions-api` / DNS, send a real question, confirm it shows in the feed

