### PR TITLE
Pull question dates closer to their questions

### DIFF
--- a/Kevin Sun/style.css
+++ b/Kevin Sun/style.css
@@ -79,6 +79,10 @@ body {
   margin-top: 0;
 }
 
+#content p.note.notop {
+  margin-top: -0.7em;
+}
+
 #content .thanks {
   margin-top: 2em;
   padding-top: 1em;


### PR DESCRIPTION
## Summary
- The "Asked <date>" notes (added in #3) sat a full paragraph-margin below their questions. New `#content p.note.notop` rule pulls them up `-0.7em` so the date hugs the question.

## Test plan
- [x] Rendered answers.html in headless Chrome — date sits snug under "Can large language models (LLMs) reason?"