### PR TITLE
Date the thoughts

### DIFF
--- a/thinking.html
+++ b/thinking.html
@@ -26,6 +26,7 @@
       <p>
         <b><i>Tenet</i> and generational conflict</b>
       </p>
+      <p class="note notop">July 15, 2024</p>
       <p>
         I don't think I gave this movie enough credit when I first watched it. I
         was too focused on the mechanics of time travel in the film, rather than
@@ -70,6 +71,7 @@
       </p>
 
       <p><b>Expanding the domain of human cognition</b></p>
+      <p class="note notop">July 12, 2024</p>
       <p>
         One university professor once told me that the economy "never grows, it
         only finds ways to monetize previously unmonetizable things"; I think a
@@ -108,6 +110,7 @@
       </p>
 
       <p><b>Second-order theories of morality and epistemic humility</b></p>
+      <p class="note notop">July 9, 2024</p>
 
       <p>
         I was captivated by an
@@ -175,6 +178,7 @@
       </p>
 
       <p><b>Consciousness, Abstraction, and Computers</b></p>
+      <p class="note notop">July 8, 2024</p>
       <p>
         I always found it interesting how the term "abstraction" is thrown
         around without much thought amongst software engineers. Abstraction is a
@@ -230,6 +234,7 @@
       </ul>
 
       <p><b>Religion as a meta-cognitive structure</b></p>
+      <p class="note notop">July 7, 2024</p>
       <p>
         I have a hypothesis that part of the mass secularization of society may
         be in part explained by the Flynn effect. We have an explosion of
@@ -253,6 +258,7 @@
       </p>
 
       <p><b>Rationalizing the irrational</b></p>
+      <p class="note notop">June 22, 2024</p>
       <p>
         I'm puzzled by people who attempt to memorize the digits of pi by
         remembering some logical relationship between the numbers (e.g. telling
@@ -316,6 +322,7 @@
       </ul>
 
       <p><b>Social Darwinism</b></p>
+      <p class="note notop">May 12, 2024</p>
       <p>
         I recently watched the <i>Kingdom of the Planet of the Apes</i> movie,
         and one element of the plot that stuck out was the primates insisting on
@@ -331,6 +338,7 @@
       </p>
 
       <p><b>Willpower / Ego Depletion</b></p>
+      <p class="note notop">April 7, 2024</p>
       <p>
         Ever since I was in high school, I thought that willpower was a finite
         commodity. You had to budget the quantity of difficult tasks that you
@@ -366,6 +374,7 @@
       </p>
 
       <p><b>Probability</b></p>
+      <p class="note notop">March 8, 2024</p>
       <p>
         Probability is not
         <a href="https://www.arameb.com/blog/2020/11/22/probability">"real"</a>.
@@ -373,6 +382,7 @@
       <p>I feel like there's a tie between this and machine learning.</p>
 
       <p><b>Social Media Musings</b></p>
+      <p class="note notop">February 14, 2024</p>
 
       <p>
         I think a more targeted analysis of what social media platforms


### PR DESCRIPTION
## Summary
- Each essay on the Thoughts page now carries a muted date note (same style as the question dates), inferred from the commit that introduced it:

| Thought | Date |
|---|---|
| *Tenet* and generational conflict | July 15, 2024 |
| Expanding the domain of human cognition | July 12, 2024 |
| Second-order theories of morality and epistemic humility | July 9, 2024 |
| Consciousness, Abstraction, and Computers | July 8, 2024 |
| Religion as a meta-cognitive structure | July 7, 2024 |
| Rationalizing the irrational | June 22, 2024 |
| Social Darwinism | May 12, 2024 |
| Willpower / Ego Depletion | April 7, 2024 |
| Probability | March 8, 2024 |
| Social Media Musings | February 14, 2024 |

(The consciousness essay's heading text first appears 7/9, but the essay itself landed 7/8 under a typo'd title — dated to the content, not the title fix.)

## Test plan
- [x] Rendered thinking.html in headless Chrome — all ten dates sit snug under their headings