### PR TITLE
Pull date notes tighter to their headers

### DIFF
--- a/Kevin Sun/style.css
+++ b/Kevin Sun/style.css
@@ -80,7 +80,7 @@ body {
 }
 
 #content p.note.notop {
-  margin-top: -0.7em;
+  margin-top: -1em;
 }
 
 #content .thanks {


### PR DESCRIPTION
## Summary
- `-0.7em` wasn't enough — the gap under the date read the same as the gap above it. Now `-1em`, so the date sits ~3px under its header vs ~13px above the body text.

## Test plan
- [x] Rendered questions.html in headless Chrome — date clearly groups with the header