### PR TITLE
Answer the creativity question with the same METR graph

### DIFF
--- a/answers.html
+++ b/answers.html
@@ -23,7 +23,7 @@
           questions <a href="questions.html">here</a>.
         </p>
 
-        <p><b>Can large language models (LLMs) reason?</b></p>
+        <p id="can-llms-reason"><b>Can large language models (LLMs) reason?</b></p>
         <p class="note notop">
           Asked April 8, 2023 · Answered June 10, 2026
         </p>
@@ -41,6 +41,17 @@
             />
           </a>
         </p>
+
+        <p>
+          <b
+            >Is it possible to statistically generalize breakthroughs in human
+            creativity?</b
+          >
+        </p>
+        <p class="note notop">
+          Asked December 29, 2023 · Answered June 10, 2026
+        </p>
+        <p>Yes. <a href="#can-llms-reason">Same answer as above.</a></p>
       </div>
     </div>
   </body>

--- a/answers.html
+++ b/answers.html
@@ -51,7 +51,7 @@
         <p class="note notop">
           Asked December 29, 2023 · Answered June 10, 2026
         </p>
-        <p>Yes. <a href="#can-llms-reason">Same answer as above.</a></p>
+        <p>Yes. <a href="#can-llms-reason">Above.</a></p>
       </div>
     </div>
   </body>

--- a/questions.html
+++ b/questions.html
@@ -115,7 +115,10 @@
             creativity?</b
           >
         </p>
-        <p class="note notop">Asked December 29, 2023</p>
+        <p class="note notop">
+          Asked December 29, 2023 ·
+          <a href="answers.html">Answered June 10, 2026</a>
+        </p>
         <p>
           Recently, I've started to reason about machine learning (ML) via some
           crude first principles reductions to statistics. Put concretely, I've


### PR DESCRIPTION
## Summary
- "Is it possible to statistically generalize breakthroughs in human creativity?" is now answered on the Answers page: "Yes. Same answer as above." — anchor-linked to the LLM answer's METR graph rather than duplicating the image.
- The Questions page marks it "Asked December 29, 2023 · Answered June 10, 2026" with a link, same as the LLM question.

## Test plan
- [x] Rendered answers.html in headless Chrome — both entries render, anchor link targets the LLM answer