### PR TITLE
Remove "Consciousness, Abstraction, and Computers" from Thoughts (re-do of #11 against main)

### DIFF
--- a/thinking.html
+++ b/thinking.html
@@ -178,62 +178,6 @@
         science fiction angle to this.
       </p>
 
-      <p><b>Consciousness, Abstraction, and Computers</b></p>
-      <p class="note notop">July 8, 2024</p>
-      <p>
-        I always found it interesting how the term "abstraction" is thrown
-        around without much thought amongst software engineers. Abstraction is a
-        rather non-trivial philosophical concept; whether they exist at all
-        outside of our conscious experience is still a very open question.
-      </p>
-      <p>
-        I find it fascinating that abstractions "work". We can't quite describe
-        what we're doing when we're generalizing an idea into its more abstract
-        variant, but for some reason, this generalization appears to be
-        necessary for us to develop any breakthrough in thinking. A question
-        emerges: what would thinking look like sans any abstractions? Is it even
-        possible to "think" without the orchestration of some limited set of
-        abstract concepts?
-      </p>
-      <p>
-        It seems extraordinarily important to develop insights into the human
-        capacity for abstraction in light of recent advances in artificial
-        intelligence. As it concerns the capacity for human thought, our
-        assessment of machines seems to be bottlenecked by our understanding of
-        ourselves.
-      </p>
-      <ul>
-        <li>
-          <a href="https://en.wikipedia.org/wiki/I_Am_a_Strange_Loop"
-            >Expansion of recursion to the study of consciousness</a
-          >
-        </li>
-        <li>
-          <a href="https://en.wikipedia.org/wiki/Man_a_Machine">Monism</a>
-        </li>
-        <li>
-          <a href="https://en.wikipedia.org/wiki/Christof_Koch"
-            >Panpsychism meets computers</a
-          >
-        </li>
-        <li>
-          <a href="https://en.wikipedia.org/wiki/Artificial_consciousness"
-            >Artificial consciousness</a
-          >
-        </li>
-        <li>
-          <a href="https://en.wikipedia.org/wiki/Holonomic_brain_theory"
-            >Quantum brains</a
-          >
-        </li>
-        <li>
-          <a
-            href="https://en.wikipedia.org/wiki/Neural_correlates_of_consciousness"
-            >SOTA neural imaging for consiousness</a
-          >
-        </li>
-      </ul>
-
       <p><b>Religion as a meta-cognitive structure</b></p>
       <p class="note notop">July 7, 2024</p>
       <p>


### PR DESCRIPTION
Replaces #11, which got merged into the `thoughts-dates` branch after #8 had already landed — so the removal never reached main.

## Summary
- Removes the "Consciousness, Abstraction, and Computers" essay (and its date note) from the Thoughts page. The other nine essays are untouched.

## Test plan
- [x] `grep -c Consciousness thinking.html` → 0