### PR TITLE
Un-bullet the fragments

### DIFF
--- a/fragments.html
+++ b/fragments.html
@@ -23,129 +23,127 @@
           Words that are progressing to thoughts. All unearned wisdom is my own.
         </p>
 
-        <ul>
-
-          <li>
+        <p>
           “Relationships are not the sum but the product of two people. Your
           great vulnerabilities and strengths are not added but multiplied.”
           <span class="note">— 6/8/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “What matters is not what I know, but whether I know what God knows.”
           <span class="note">— 6/8/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Any time you feel an ache in your back or pain in your fingers,
           remember that just because you don’t do the work doesn’t mean the work
           doesn’t get done. It just gets done by someone else.”
           <span class="note">— 6/8/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “People are forcing functions. You should care more about what they
           want from you than what you want in them. Would you be happy if you
           became what they wanted?” <span class="note">— 6/6/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “In moments of grief, we find ourselves blessed with a special kind of
           suffering: a pain that’s so powerful that it reminds us that we are,
           in fact, alive.” <span class="note">— 5/30/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Once you believe that you’ve eliminated all threats to your life, you
           become your own greatest threat.”
           <span class="note">— 5/23/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “There is no third person. You’re always choosing whose eyes you’re
           seeing the world through.” <span class="note">— 5/14/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Spanish conquistadors wasted their whole life looking for the
           fountain of youth. In the pursuit of everlasting life, they lost the
           only one they truly had.
           <br /><br />
           The fountain of youth overflows with the lives lost pursuing it.”
           <span class="note">— 5/14/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “A man is what he’s looking for.” <span class="note">— 4/14/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Every technology removes a barrier between what is in the heart and
           what is in this world. We inch closer to seeing what we desire. Do we
           desire to see what we desire? Do we even desire what we desire?”
           <span class="note">— 4/9/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “A sufficiently detailed question is indistinguishable from
           understanding.” <span class="note">— 4/5/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “The best language for communicating an apology is action.”
           <span class="note">— 4/2/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “The difference between art and engineering isn’t precision. The
           difference is the constraints.
           <br /><br />
           Art doesn’t scale. Engineering does.”
           <span class="note">— 3/28/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “You say you want peace, but you complain that you’re bored. You love
           ambient noise. You distract yourself with electronic trinkets.
           <br /><br />
           Your behaviors defy your tongue. You don’t desire peace. You want low
           effort pleasure.” <span class="note">— 1/28/2026</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Pity is an interesting feeling because it reveals all the things you
           take pride in. Self-pity makes no sense because it’s taking pride in
           things that you don’t have.” <span class="note">— 12/25/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Is this world enough for you?” <span class="note">— 12/23/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Every day your yesterday dies. Your tomorrow must rise and be born
           again. Stagnation is suicide.” <span class="note">— 12/23/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “A circle is a finite compression of the infinite digits of pi.”
           <span class="note">— 12/23/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “We stand in the shadows of our future.”
           <span class="note">— 12/23/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “We’re all desperately trying to crack the mystery of our death. We
           spend our whole lives asking one question: how are we going to die?
           Once we find out, we change the question: why?”
           <span class="note">— 12/23/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Every automation problem is a robotics problem.”
           <span class="note">— 12/20/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Obesity led to dieting. VR led to IRL. Oversupply creates a demand
           for scarcity.” <span class="note">— 12/14/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “A good teacher will teach you the right answers. An excellent teacher
           will teach you the right questions.”
           <span class="note">— 11/8/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “It’s hard, but not that smart.”
           <span class="note">— 10/23/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “You say you want peace but what you really want is change.”
           <span class="note">— 9/14/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Who said that the manifestation of all your desires would look like a
           person?
           <br /><br />
@@ -154,50 +152,50 @@
           <br /><br />
           The greatest constraint on our imagination for a life partner is that
           they have to be a person.” <span class="note">— 8/23/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “The best way to make something stand out is by making everything else
           look the same.” <span class="note">— 8/18/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “The weight of other people’s thoughts is heavy. Don’t be Atlas.”
           <span class="note">— 7/25/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “In intelligence, there is no free lunch. IQ points are just the
           memories of your ancestors accumulated in genes.
           <br /><br />
           Either you learned it, or your ancestors did.”
           <span class="note">— 7/25/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “We have always been cannibalizing the value of intelligence by
           finding better ways of sharing it. First we had libraries, then we had
           search engines, and now we have even better non-deterministic language
           databases called language models.”
           <span class="note">— 7/17/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “There’s only one way to build confidence in other people. This
           happens to be the only way to build confidence in yourself. Keep your
           promises.” <span class="note">— 7/1/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Do not look to anyone else to save you. You are the strongest of them
           all.” <span class="note">— 6/23/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “When you have too many thoughts, you mistake distraction for
           burnout.” <span class="note">— 6/19/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Time is never wasted, just lost. We must be resourceful with our
           past.” <span class="note">— 6/19/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Do you want what you want?” <span class="note">— 6/12/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “People are just problem specifications—we’re defined by our issues,
           not our solutions.
           <br /><br />
@@ -205,68 +203,68 @@
           more powerful problems to defeat the old ones.
           <br /><br />
           Choose wisely.” <span class="note">— 5/22/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “There are no mirrors, only windows.”
           <span class="note">— 5/13/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “What happens when you automate away all low entropy decisions? You’re
           only left with high entropy decisions—or, just deep uncertainty. This
           might explain some of the rise in anxiety levels. When there’s no
           default, there’s no direction.” <span class="note">— 5/13/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “People have a tendency to act when they should just observe. People
           have a tendency to observe when they should just act. People have a
           tendency to do both when they should do one at a time.”
           <span class="note">— 4/11/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “We spend most of our lives not knowing how we think. It is only when
           we put pen to paper that we see who we really are. Writing is a mirror
           for your mind.” <span class="note">— 4/5/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Bullies are great at one on one. They tend to lose in team sports.”
           <span class="note">— 3/16/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Growth is when you look back into the past and see memories of
           another person’s life.” <span class="note">— 3/9/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Most folks treat their video game characters better than themselves.
           Would you have your protagonist sit on a couch and watch Netflix all
           day?” <span class="note">— 3/8/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Your objectives define your identity. What you want to be becomes who
           you are.” <span class="note">— 3/6/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “One implication of the is/ought distinction is that the world as it
           is, will never be the world as it should be.”
           <span class="note">— 2/28/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “You don’t learn language. You learn communication.”
           <span class="note">— 2/13/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “The wise seek challenge. Challenge seeks the fool.”
           <span class="note">— 2/12/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “No matter which direction we go, we’ll have to walk on our own two
           feet.” <span class="note">— 2/4/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “We thought that getting rid of meritocracy would produce equality —
           instead what we got was a gerontocracy.”
           <span class="note">— 1/26/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “If you take nothing for granted, this world is fair.
           <br />
           If you take everything for granted, this world is fair.
@@ -275,88 +273,88 @@
           <br /><br />
           Whatever you do, don’t take something for granted.”
           <span class="note">— 1/17/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Your bones will grind to dust. All that will be left is what you once
           stood for.” <span class="note">— 1/16/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Consider bouldering. You have rocks serving as objects to hoist your
           body. Life is spiritual bouldering. You have physical artifacts
           serving as objects for your spiritual struggles. The beauty of this
           analogy is that you can follow it all the way into the mountain. What
           are the rocks connected to? Well, more rocks.”
           <span class="note">— 1/16/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Confront your fears. You might lose, but at least you won’t lose to
           yourself.” <span class="note">— 1/14/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “We don’t have nearly enough conversations to only learn from the
           interesting ones.” <span class="note">— 1/14/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Life offers us a privilege: to choose your fear. Fear God or fear
           this world.” <span class="note">— 1/11/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Disposition emerges from discipline.”
           <span class="note">— 1/11/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Stepping into the light reveals your imperfections.”
           <span class="note">— 1/11/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “You can’t be yourself when you’re thinking about yourself.”
           <span class="note">— 1/11/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Everyone starts walking together on the coast. Some lock arms and
           charge into the ocean together. Others let go and walk in by
           themselves. With time, the currents will wash us all into uncharted
           water—leaving us to wander alone.”
           <span class="note">— 1/10/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Whichever direction is forward for you, may you go boldly.”
           <span class="note">— 1/10/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “People give advice that’s top of mind. Advice that’s top of mind is
           usually advice they’re giving themselves.”
           <span class="note">— 1/10/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Truth takes time, sometimes longer than your lifetime.”
           <span class="note">— 1/9/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “You either believe in God or have a God complex.”
           <span class="note">— 1/9/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Buddhists mistake the noble path for the noble lie.”
           <span class="note">— 1/9/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “The better you are, the weirder your problems.”
           <span class="note">— 1/8/2025</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “You think you’ve built a castle but you’ve built a prison.”
           <span class="note">— 12/28/2024</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Moments have to find the right time.”
           <span class="note">— 12/28/2024</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “The curse of having a good memory is that you have trouble moving
           on.” <span class="note">— 12/28/2024</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Consider Michelangelo’s Pieta.
           <br /><br />
           Zoom into any small corner — you’ll find that a man had chipped away
@@ -366,47 +364,46 @@
           <br /><br />
           Many imperfections create perfection.”
           <span class="note">— 12/1/2024</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Money matters more when you have less.”
           <span class="note">— 11/29/2024</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “We’re told that if you ‘dream hard enough’ that ‘anything is
           possible’. Of course anything is possible because it’s just your
           dream.” <span class="note">— 11/29/2024</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Great dreams are those tempered by reality.”
           <span class="note">— 11/29/2024</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “You’re putting words to feelings and mistaking them for thoughts.”
           <span class="note">— 11/26/2024</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “The only person who desires to be the ‘real you’ is the ‘fake you’.”
           <span class="note">— 11/26/2024</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “You are what’s obvious to you.”
           <span class="note">— 11/26/2024</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Achievement is a function of will and power. He who has everything
           has everything to lose. He who has nothing has nothing to use.”
           <span class="note">— 9/18/2024</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Everything that is, was, or will ever be true — already is. We’re
           just finding the symbols to represent them.”
           <span class="note">— 3/2024</span>
-          </li>
-          <li>
+        </p>
+        <p>
           “Success is as much a function of what you’re good at as it is what
           you’re bad at.” <span class="note">— ~2023</span>
-          </li>
-        </ul>
+        </p>
       </div>
     </div>
   </body>


### PR DESCRIPTION
## Summary
- Reverts #12 — the fragments go back to plain paragraphs, no bullets.

## Test plan
- [x] The only `<ul>`/`<li>` left in fragments.html is the navigation menu